### PR TITLE
Handle multi runtimes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const BbPromise = require('bluebird');
 const pack = require('./lib/pack');
 const getPackingInfo = require('./lib/pack');
+const funcRuntimeIsDotNet = require('./lib/pack');
 
 class ServerlessDotNet {
   constructor(serverless, options) {
@@ -13,11 +14,12 @@ class ServerlessDotNet {
       
       Object.assign( this, pack );
       Object.assign( this, getPackingInfo );
+      Object.assign( this, funcRuntimeIsDotNet )
 
       this.hooks = {
         'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.pack)
       };
-    }
+    } 
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -7,6 +7,9 @@ test('Given no projectFolder set - getPackingInfo uses first folder as working f
     const serverlessMock = {
 
         service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
             getAllFunctions: () => {
                 return [{
                         package: {
@@ -32,6 +35,9 @@ test('Given projectFolder set - getPackingInfo uses projectFolder as current wor
     const expCwd = projectFolder;
     const serverlessMock = {
         service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
             getAllFunctions: () => {
                 return [{
                         package: {
@@ -56,6 +62,9 @@ test('Given projectFolder set to non root folder - getPackingInfo throws excepti
     const projectFolder = "src/app/folder2";    
     const serverlessMock = {
         service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
             getAllFunctions: () => {
                 return [{
                         package: {
@@ -88,6 +97,9 @@ test('Given projectFolder empty - getPackingInfo uses first folder as package fo
     const expCwd = "folder";
     const serverlessMock = {
         service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
             getAllFunctions: () => {
                 return [{
                         package: {
@@ -105,4 +117,129 @@ test('Given projectFolder empty - getPackingInfo uses first folder as package fo
     expect(Object.entries(packingInfo).length).toBe(1);
     expect(packingInfo[artifactPath].currentWorkingDir).toBe(expCwd);
     expect(packingInfo[artifactPath].artifactOutput).toBe(expOutputPath);
+});
+
+test('Given provider runtime set to dotnet and no func runtimes set with single func, getPackingInfo returns data for all funcs', () => {
+    const artifactPath = "folder/publish/deploy-package.zip";
+    const serverlessMock = {
+        service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
+            getAllFunctions: () => {
+                return [
+                    {
+                        package: {
+                            artifact: artifactPath,
+                        }
+                    }
+                ]
+            },
+            getFunction: (func) => func
+        }
+    };
+    const sut = new ServerlessDotNet(serverlessMock, {});
+    const packingInfo = sut.getPackingInfo();
+    expect(Object.entries(packingInfo).length).toBe(1);
+});
+
+test('Given provider runtime set to dotnet and no func runtimes set with multiple func, getPackingInfo returns data for all funcs', () => {
+    const artifactPath = "folder/publish/deploy-package.zip";
+    const artifactPath2 = "folder/publish/deploy-package2.zip";
+    const serverlessMock = {
+        service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
+            getAllFunctions: () => {
+                return [
+                    {
+                        package: {
+                            artifact: artifactPath,
+                        },
+                        
+                    },
+                    {
+                        package: {
+                            artifact: artifactPath2,
+                        }
+                    }
+                ]
+            },
+            getFunction: (func) => func
+        }
+    };
+    const sut = new ServerlessDotNet(serverlessMock, {});
+    const packingInfo = sut.getPackingInfo();
+    expect(Object.entries(packingInfo).length).toBe(2);
+});
+
+test('Given provider runtime set to dotnet and mixed func runtimes set with multiple func, getPackingInfo returns data for only dotnet funcs', () => {
+    const artifactPath = "folder/publish/deploy-package.zip";
+    const artifactPath2 = "folder/publish/deploy-package2.zip";
+    const artifactPath3 = "folder/publish/deploy-package3.zip";
+    const serverlessMock = {
+        service: {
+            provider: {
+                runtime: 'dotnetcore2.1'
+            },
+            getAllFunctions: () => {
+                return [
+                    {
+                        runtime: 'dotnetcore2.1',
+                        package: {
+                            artifact: artifactPath,
+                        },
+                        
+                    },
+                    {
+                        runtime: 'nodejs10.x',
+                        package: {
+                            artifact: artifactPath2,
+                        }
+                    },
+                    {
+                        package: {
+                            artifact: artifactPath3,
+                        }
+                    }
+                ]
+            },
+            getFunction: (func) => func
+        }
+    };
+    const sut = new ServerlessDotNet(serverlessMock, {});
+    const packingInfo = sut.getPackingInfo();
+    expect(Object.entries(packingInfo).length).toBe(2);
+});
+
+test('Given no provider runtime set and func runtimes set to dotnet with multiple func, getPackingInfo returns data for all funcs', () => {
+    const artifactPath = "folder/publish/deploy-package.zip";
+    const artifactPath2 = "folder/publish/deploy-package2.zip";
+    const serverlessMock = {
+        service: {
+            provider: {},
+            getAllFunctions: () => {
+                return [
+                    {
+                        runtime: 'dotnetcore2.1',
+                        package: {
+                            artifact: artifactPath,
+                        },
+                        
+                    },
+                    {
+                        runtime: 'dotnetcore2.1',
+                        package: {
+                            artifact: artifactPath2,
+                        }
+                    }
+                ]
+            },
+            getFunction: (func) => func
+        }
+    };
+    const sut = new ServerlessDotNet(serverlessMock, {});
+    const packingInfo = sut.getPackingInfo();
+    expect(Object.entries(packingInfo).length).toBe(2);
 });

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -9,8 +9,18 @@ module.exports = {
 
     let service = this.serverless.service;
 
-    const packages = service.getAllFunctions().map(func => service.getFunction(func).package);
+    const packages = service.getAllFunctions().reduce((dotnetPackages, funcName) => {
+      let func = service.getFunction(funcName);
+
+      if (this.funcRuntimeIsDotNet(service, func)) {
+        dotnetPackages.push(func.package);
+      }
+
+      return dotnetPackages;
+    }, [])
+    
     let dicArtifacts = {};
+
     packages.forEach(p => {
 
       const projectFolder = p.projectFolder || "";
@@ -18,7 +28,6 @@ module.exports = {
       if (projectFolder && !p.artifact.startsWith(projectFolder)){
         const error = `Serverless DotNet: function/package/projectFolder '${projectFolder}' is defined and should be root of function/package/artifact path '${p.artifact}'. Pleas update your configuration...`;
         throw new Error(error);
-      
       }
 
       var artifactPathParts = p.artifact.split(/\\|\//);
@@ -35,14 +44,27 @@ module.exports = {
       // console.log('cwd parts: ' +cwdParts);
       // console.log('artifact less cwd parts: ' +artifactLessProjectFolderParts);
 
-      dicArtifacts[p.artifact] = { 
-        currentWorkingDir: cwd, 
+      dicArtifacts[p.artifact] = {
+        currentWorkingDir: cwd,
         artifactOutput: artifactLessProjectFolderParts.join('/')
-      } 
+      }
     });
 
     return dicArtifacts;
 
+  },
+
+  funcRuntimeIsDotNet(service, func) {
+    let providerRuntime = service.provider.runtime;
+    let funcRuntime = func.runtime;
+
+    if (!providerRuntime && !funcRuntime) {
+      console.error('No runtime found at global provider or local function level, eg. dotnetcore2.1')
+    }
+  
+    return (providerRuntime && providerRuntime.startsWith('dotnet') && !funcRuntime)
+        || (funcRuntime && funcRuntime.startsWith('dotnet'))
+        || (!providerRuntime && funcRuntime && funcRuntime.startsWith('dotnet'));
   },
 
   pack() {
@@ -53,7 +75,7 @@ module.exports = {
 
     var promises = Object.entries(dicArtifacts).map(kv => {
       return new BbPromise(function (resolve, reject) {
-        
+
         try {
           const packingInfo = kv[1];
           program.exec('dotnet lambda package -o ' + packingInfo.artifactOutput, { "cwd": packingInfo.currentWorkingDir }, function (error, stdout, stderr) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-multi-dotnet",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1568,7 +1568,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1589,12 +1590,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1609,17 +1612,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1736,7 +1742,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1748,6 +1755,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1762,6 +1770,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1769,12 +1778,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1793,6 +1804,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1873,7 +1885,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1885,6 +1898,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1970,7 +1984,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2006,6 +2021,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2025,6 +2041,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2068,12 +2085,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-multi-dotnet",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A Serverless plugin to pack lambdas in multiple C# projects using dotnen lambda package command.",
   "main": "index.js",
   "author": "Michael Tsibelman",


### PR DESCRIPTION
I ran into issues using this plugin with a serverless template that contained functions with different runtimes. I have added some logic to determine if a function's runtime will be dotnet as part of getPackingInfo(). Test have been added to support this.