### PR TITLE
Use package:createDeploymentArtifacts hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class ServerlessDotNet {
       Object.assign( this, funcRuntimeIsDotNet )
 
       this.hooks = {
-        'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.pack)
+        'package:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.pack)
       };
     } 
   }


### PR DESCRIPTION
Solves:

    Serverless: WARNING: Plugin ServerlessDotNet uses deprecated hook after:deploy:createDeploymentArtifacts,
                     use package:createDeploymentArtifacts hook instead

needs testing